### PR TITLE
Fixing Multiple Completions Firing and Adding Toggle Checkbox for Text Updating on Completion

### DIFF
--- a/XLMapExtensions/ItemCollectorManager.cs
+++ b/XLMapExtensions/ItemCollectorManager.cs
@@ -27,7 +27,11 @@ namespace XLMapExtensions
         [Tooltip("Use this to control the format of the status text.")]
         public string StatusTextFormat = "{0} of {1} collected...";
 
+        [Tooltip("A reference to the TMP Text object you'd like to have updated.")]
         public TMP_Text TextToUpdate;
+
+        [Tooltip("Toggle this on if you'd like to have the TextToUpdate get updated after collecting all items.")]
+        public bool UpdateStatusTextOnCompletion;
 
         private int _itemsCollected;
 
@@ -64,11 +68,18 @@ namespace XLMapExtensions
 
             _collectedItems.Add(item);
 
-            TextToUpdate?.SetText(CurrentStatusText);
-
             if (_itemsCollected == NumberOfItemsToCollect)
             {
                 ItemsCollectedEvent.Invoke();
+
+                if (UpdateStatusTextOnCompletion)
+                {
+                    TextToUpdate?.SetText(CurrentStatusText);
+                }
+            }
+            else
+            {
+                TextToUpdate?.SetText(CurrentStatusText);
             }
         }
     }

--- a/XLMapExtensions/ItemCollectorManager.cs
+++ b/XLMapExtensions/ItemCollectorManager.cs
@@ -64,12 +64,9 @@ namespace XLMapExtensions
 
             _collectedItems.Add(item);
 
-            if (TextToUpdate != null)
-            {
-                TextToUpdate.SetText(CurrentStatusText);
-            }
+            TextToUpdate?.SetText(CurrentStatusText);
 
-            if (_itemsCollected >= NumberOfItemsToCollect)
+            if (_itemsCollected == NumberOfItemsToCollect)
             {
                 ItemsCollectedEvent.Invoke();
             }

--- a/XLMapExtensions/Triggers/ItemCollectorManager.cs
+++ b/XLMapExtensions/Triggers/ItemCollectorManager.cs
@@ -19,10 +19,10 @@ namespace XLMapExtensions.Triggers
         public int NumberOfItemsToCollect;
 
         [Tooltip("Fired when NumberOfItemsToCollect has been met.")]
-        public UnityEvent ItemsCollectedEvent;
+        public UnityEvent CompletedEvent;
 
         [Tooltip("Fired each time an item is collected.")]
-        public GameObjectUnityEvent ItemCollectedEvent;
+        public GameObjectUnityEvent CollectedEvent;
 
         [Tooltip("Use this to control the format of the status text.")]
         public string StatusTextFormat = "{0} of {1} collected...";
@@ -44,14 +44,14 @@ namespace XLMapExtensions.Triggers
 
             _collectedItems = new List<GameObject>();
 
-            if (ItemsCollectedEvent == null)
+            if (CompletedEvent == null)
             {
-                ItemsCollectedEvent = new UnityEvent();
+                CompletedEvent = new UnityEvent();
             }
 
-            if (ItemCollectedEvent == null)
+            if (CollectedEvent == null)
             {
-                ItemCollectedEvent = new GameObjectUnityEvent();
+                CollectedEvent = new GameObjectUnityEvent();
             }
 
             if (TextToUpdate != null)
@@ -64,13 +64,13 @@ namespace XLMapExtensions.Triggers
         {
             _itemsCollected++;
 
-            ItemCollectedEvent.Invoke(item);
+            CollectedEvent.Invoke(item);
 
             _collectedItems.Add(item);
 
             if (_itemsCollected == NumberOfItemsToCollect)
             {
-                ItemsCollectedEvent.Invoke();
+                CompletedEvent.Invoke();
 
                 if (UpdateStatusTextOnCompletion)
                 {


### PR DESCRIPTION
- There was a bug where we would fire the collection completed event multiple times after you'd exceeded the number to collect.
- Adding a toggle check box so that you can control whether or not the text to update gets updated upon completion.
- Renaming the event names to be more clear.