### PR TITLE
Add Min Time Between Events for All Trigger Events

### DIFF
--- a/XLMapExtensions/Triggers/BoardTriggerBase.cs
+++ b/XLMapExtensions/Triggers/BoardTriggerBase.cs
@@ -6,11 +6,42 @@ namespace XLMapExtensions.Triggers
     [Serializable]
     public class BoardTriggerBase : MonoBehaviour
     {
+        public float minTimeBetweenEvents;
+        [Tooltip("Used only if minTimeBetweenEvents > 0.")]
+        public bool useUnscaledTime;
+
         protected Collider _boardCollider;
+
+        private float time => !useUnscaledTime ? Time.time : Time.unscaledTime;
+        private float lastEventTime = float.MinValue;
 
         protected virtual void Start()
         {
             _boardCollider = PlayerController.Instance.boardController.boardColliders[0];
+        }
+
+        /// <summary>
+        /// A way to rate-limit trigger events from being fired.  If <see cref="minTimeBetweenEvents"/> was set to 0, this will always return true.  Else, it will check to see
+        /// if enough time has elapsed (<see cref="minTimeBetweenEvents"/>) since the last firing and return whether or not it's capable to be fired again.
+        /// </summary>
+        /// <returns>True if enough time has elapsed since the last event was fired.  Returns false if not enough time has since the last event.</returns>
+        protected bool CanBeFiredAgain()
+        {
+            if (minTimeBetweenEvents != 0 && time - minTimeBetweenEvents < lastEventTime)
+                return false;
+
+            lastEventTime = time;
+            return true;
+        }
+
+        /// <summary>
+        /// Used by editor to ensure <see cref="minTimeBetweenEvents" /> is never set negative.
+        /// </summary>
+        private void OnValidate()
+        {
+            if (minTimeBetweenEvents >= 0.0) return;
+
+            minTimeBetweenEvents = 0.0f;
         }
     }
 }

--- a/XLMapExtensions/Triggers/CollectorManager.cs
+++ b/XLMapExtensions/Triggers/CollectorManager.cs
@@ -115,6 +115,7 @@ namespace XLMapExtensions.Triggers
         private void OnTriggerEnter(Collider collider)
         {
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             _itemCollectedManagerEvent?.Invoke(collider.gameObject);
         }
@@ -122,7 +123,8 @@ namespace XLMapExtensions.Triggers
         private void OnTriggerExit(Collider collider)
         {
             if (collider != _boardCollider) return;
-            
+            if (!CanBeFiredAgain()) return;
+
             CollectedEvent.Invoke(collider.gameObject);
         }
     }

--- a/XLMapExtensions/Triggers/GearDownloadOnTrigger.cs
+++ b/XLMapExtensions/Triggers/GearDownloadOnTrigger.cs
@@ -22,6 +22,7 @@ namespace XLMapExtensions.Triggers
         private void OnTriggerEnter(Collider collider)
         {
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             if (string.IsNullOrEmpty(imageDownloadUrl)) return;
 

--- a/XLMapExtensions/Triggers/PlayerCheckpointOnTrigger.cs
+++ b/XLMapExtensions/Triggers/PlayerCheckpointOnTrigger.cs
@@ -13,6 +13,7 @@ namespace XLMapExtensions.Triggers
         {
             if (CheckpointLocation == null) return;
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             // Sets spawn position such that the next time the player bails or tries to go back to their marker, they go to the checkpoint
             PlayerController.Instance.respawn.SetSpawnPos(CheckpointLocation.position, CheckpointLocation.rotation);

--- a/XLMapExtensions/Triggers/RespawnOnTrigger.cs
+++ b/XLMapExtensions/Triggers/RespawnOnTrigger.cs
@@ -9,6 +9,7 @@ namespace XLMapExtensions.Triggers
         private void OnTriggerEnter(Collider collider)
         {
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             PlayerController.Instance.respawn.DoRespawn();
         }

--- a/XLMapExtensions/Triggers/SetRandomObjectActive.cs
+++ b/XLMapExtensions/Triggers/SetRandomObjectActive.cs
@@ -19,6 +19,7 @@ namespace XLMapExtensions.Triggers
         {
             if (!GameObjects.Any()) return;
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             var randomObjectIndex = Random.Range(0, GameObjects.Count);
 

--- a/XLMapExtensions/Triggers/StopOnTrigger.cs
+++ b/XLMapExtensions/Triggers/StopOnTrigger.cs
@@ -24,6 +24,7 @@ namespace XLMapExtensions.Triggers
         private void OnTriggerEnter(Collider collider)
         {
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             _skaterRigidbody.constraints = RigidbodyConstraints.FreezeAll;
             _boardRigidbody.constraints = RigidbodyConstraints.FreezeAll;

--- a/XLMapExtensions/Triggers/TeleportPlayerOnTrigger.cs
+++ b/XLMapExtensions/Triggers/TeleportPlayerOnTrigger.cs
@@ -13,6 +13,7 @@ namespace XLMapExtensions.Triggers
         {
             if (LocationToTeleport == null) return;
             if (collider != _boardCollider) return;
+            if (!CanBeFiredAgain()) return;
 
             PlayerController.Instance.respawn.SetSpawnPos(LocationToTeleport.position, LocationToTeleport.rotation);
             PlayerController.Instance.respawn.DoRespawn();


### PR DESCRIPTION
- Inspired by the MinTimeBetweenEvents implementation in Easy Day's SDK, this brings that same functionality to all of these trigger based events, in order to provide some rate-limiting capabilities.
- This work will close #11.