### PR TITLE
PlayerReference Enhancements

### DIFF
--- a/XLMapExtensions/PlayerReference.cs
+++ b/XLMapExtensions/PlayerReference.cs
@@ -5,18 +5,90 @@ using UnityEngine;
 
 namespace XLMapExtensions
 {
+    public enum TargetType
+    {
+        SkaterHead,
+        SkaterChest,
+        SkaterHips,
+        Skateboard,
+        BackTruck,
+        FrontTruck,
+        BackTruckWheel1,
+        BackTruckWheel2,
+        FrontTruckWheel3,
+        FrontTruckWheel4
+    }
+
     [Serializable]
     public class PlayerReference : MonoBehaviour
     {
+        public TargetType Target = TargetType.SkaterHips;
+
+        [Tooltip("Check this to update the target game object's rotation as well as position.")]
+        public bool UpdateRotation;
+
+        private static string SkaterRoot = "NewSkater/Skater_Joints/Skater_root";
+        private static string SkaterPelvis = $"{SkaterRoot}/Skater_pelvis";
+        private static string SkaterSpine2 = $"{SkaterPelvis}/Skater_Spine/Skater_Spine1/Skater_Spine2";
+        private static string SkaterHead = $"{SkaterSpine2}/Skater_Neck/Skater_Head";
+        private static string Skateboard = "Skateboard/Deck";
+        private static string BackTruckHanger = $"{Skateboard}/Back Truck/Hanger";
+        private static string FrontTruckHanger = $"{Skateboard}/Front Truck/Hanger";
+        private static string Wheel1 = $"{BackTruckHanger}/Wheel1";
+        private static string Wheel2 = $"{BackTruckHanger}/Wheel2";
+        private static string Wheel3 = $"{FrontTruckHanger}/Wheel3";
+        private static string Wheel4 = $"{FrontTruckHanger}/Wheel4";
+
         private void Update()
         {
-            if (GameStateMachine.Instance.CurrentState.GetType() == typeof(ReplayState))
+
+            // replay doesn't work, needs `Playback Skater Root` in front of find path
+            var transformToUse = GameStateMachine.Instance.CurrentState.GetType() == typeof(ReplayState)
+                ? ReplayEditorController.Instance.transform
+                : PlayerController.Instance.transform;
+
+            gameObject.transform.position = GetReferencePosition(transformToUse);
+
+            if (UpdateRotation)
             {
-                gameObject.transform.position = ReplayEditorController.Instance.transform.Find("Playback Skater Root/NewSkater/Skater_Joints/Skater_root/Skater_pelvis").position;
+                gameObject.transform.rotation = GetReferenceRotation(transformToUse);
             }
-            else
+        }
+
+        private Vector3 GetReferencePosition(Transform topLevelTransform)
+        {
+            switch (Target)
             {
-                gameObject.transform.position = PlayerController.Instance.skaterController.skaterHips.position;
+                case TargetType.SkaterHips: return topLevelTransform.Find(SkaterPelvis).position;
+                case TargetType.SkaterChest: return topLevelTransform.Find(SkaterSpine2).position;
+                case TargetType.SkaterHead: return topLevelTransform.Find(SkaterHead).position;
+                case TargetType.Skateboard: return topLevelTransform.Find(Skateboard).position;
+                case TargetType.BackTruck: return topLevelTransform.Find(BackTruckHanger).position;
+                case TargetType.FrontTruck: return topLevelTransform.Find(FrontTruckHanger).position;
+                case TargetType.BackTruckWheel1: return topLevelTransform.Find(Wheel1).position;
+                case TargetType.BackTruckWheel2: return topLevelTransform.Find(Wheel2).position;
+                case TargetType.FrontTruckWheel3: return topLevelTransform.Find(Wheel3).position;
+                case TargetType.FrontTruckWheel4: return topLevelTransform.Find(Wheel4).position;
+                default: return Vector3.up;
+            }
+        }
+
+        
+        private Quaternion GetReferenceRotation(Transform topLevelTransform)
+        {
+            switch (Target)
+            {
+                case TargetType.SkaterHips: return topLevelTransform.Find(SkaterPelvis).rotation;
+                case TargetType.SkaterChest: return topLevelTransform.Find(SkaterSpine2).rotation;
+                case TargetType.SkaterHead: return topLevelTransform.Find(SkaterHead).rotation;
+                case TargetType.Skateboard: return topLevelTransform.Find(Skateboard).rotation;
+                case TargetType.BackTruck: return topLevelTransform.Find(BackTruckHanger).rotation;
+                case TargetType.FrontTruck: return topLevelTransform.Find(FrontTruckHanger).rotation;
+                case TargetType.BackTruckWheel1: return topLevelTransform.Find(Wheel1).rotation;
+                case TargetType.BackTruckWheel2: return topLevelTransform.Find(Wheel2).rotation;
+                case TargetType.FrontTruckWheel3: return topLevelTransform.Find(Wheel3).rotation;
+                case TargetType.FrontTruckWheel4: return topLevelTransform.Find(Wheel4).rotation;
+                default: return Quaternion.identity;
             }
         }
     }

--- a/XLMapExtensions/RandomSpawnpoint.cs
+++ b/XLMapExtensions/RandomSpawnpoint.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace XLMapExtensions.Triggers
+namespace XLMapExtensions
 {
     [Serializable]
     public class RandomSpawnpoint : MonoBehaviour

--- a/XLMapExtensions/XLMapExtensions.csproj
+++ b/XLMapExtensions/XLMapExtensions.csproj
@@ -103,7 +103,7 @@
     <Compile Include="Triggers\CollectorManager.cs" />
     <Compile Include="Triggers\PlayerCheckpointOnTrigger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Triggers\RandomSpawnpoint.cs" />
+    <Compile Include="RandomSpawnpoint.cs" />
     <Compile Include="Triggers\RespawnOnTrigger.cs" />
     <Compile Include="Triggers\SetRandomObjectActive.cs" />
     <Compile Include="Triggers\StopOnTrigger.cs" />


### PR DESCRIPTION
- Moved RandomSpawnpoint script out of triggers folder and into project root.
- Previously only offered a way to target the skater's hips and update a game object's position.
- Added toggle checkbox to conditionally update the object's rotation.
- Added the following target types for them to be able to use:
  - skater's head
  - skater's chest
  - skateboard
  - front truck hanger
  - back truck hanger
  - back truck wheel 1
  - back truck wheel 2
  - front truck wheel 3
  - front truck wheel 4
- This work closes #4 and closes #5.