### PR TITLE
Prevent Duplicate Downloads

### DIFF
--- a/XLMapExtensions/Triggers/GearDownloadOnTrigger.cs
+++ b/XLMapExtensions/Triggers/GearDownloadOnTrigger.cs
@@ -31,6 +31,11 @@ namespace XLMapExtensions.Triggers
 
         private IEnumerator DownloadImageCoroutine()
         {
+            var destinationPath = GetDestinationPath();
+            var destinationFileName = Path.Combine(destinationPath, downloadFilename);
+
+            if (File.Exists(destinationFileName)) yield break;
+
             using (var request = UnityWebRequestTexture.GetTexture(imageDownloadUrl))
             {
                 yield return request.SendWebRequest();
@@ -42,10 +47,7 @@ namespace XLMapExtensions.Triggers
 
                 var bytes = textureDownloadHandler.texture.EncodeToPNG();
 
-                var destinationPath = GetDestinationPath();
                 if (!Directory.Exists(destinationPath)) Directory.CreateDirectory(destinationPath);
-
-                var destinationFileName = Path.Combine(destinationPath, downloadFilename);
 
                 File.WriteAllBytes(destinationFileName, bytes);
 


### PR DESCRIPTION
- The download script was pretty dumb, so a user could in theory download the same item over and over if they continued to activate the trigger.  To avoid wasting the bandwidth to download something the user already has, check if the file exists.  If the file already exists, assume the user has the item and bypass the download entirely.
- This work will close #27.